### PR TITLE
add isAllowIllegalAugmentsEnabled

### DIFF
--- a/src/_options.h
+++ b/src/_options.h
@@ -60,6 +60,9 @@ bool isOldModelHorseSupportEnabled = false;
 // This requires custom server side code that is not in eqemu master branch, and in majority of cases can be left false
 bool isReportHardwareAddressEnabled = false;
 
+// isAllowIllegalAugmentsEnabled if set to true will allow inserting augments which create combinations that the player cannot use.
+bool isAllowIllegalAugmentsEnabled = false;
+
 // ***** NPC *******
 
 // areCustomNPCsEnabled if set to true will allow the NPCs defined in NPCs[] to be injected in game

--- a/src/eqgame.cpp
+++ b/src/eqgame.cpp
@@ -829,6 +829,11 @@ void InitHooks()
 		PatchA((DWORD*)var, "\x32\xC0", 2); // No mount models
 	}
 
+	if (isAllowIllegalAugmentsEnabled) {
+		var = (((DWORD)0x006a8448 - 0x400000) + baseAddress);
+		PatchA((DWORD*)var, "\x90\x90\x90\x90\x90\x90", 6);
+	}
+
 	var = (((DWORD)0x004C3250 - 0x400000) + baseAddress);
 	EzDetour((DWORD)var, HandleWorldMessage_Detour, HandleWorldMessage_Trampoline);
 


### PR DESCRIPTION
adds an option to disable aug combines that produce 'The result of this combine would be both NO TRADE and unusable by you.'